### PR TITLE
fix: hover modal trigger in the calendar component

### DIFF
--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -109,7 +109,7 @@ export function Calendar({
                   key={index}
                   className="relative flex flex-col items-center"
                   onMouseEnter={(e) => {
-                    if (hasEvent(date)) {
+                    if (hasEvent(date) && isCurrentMonth) {
                       setHoveredDate(date);
                       setTooltipAnchor(e.currentTarget);
                     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4a55bce3-a00d-41a5-92a3-2aa0dabd2ba5)

Even if a day was disabled for the current month, the hover modal would still be triggered if there was an event on that day (as seen in the image for March 30th).