### PR TITLE
fix: internationalization in partners page

### DIFF
--- a/src/components/shortcut-button.tsx
+++ b/src/components/shortcut-button.tsx
@@ -22,7 +22,7 @@ export const ShortcutButton: React.FC<ShortcutButtonProps> = ({
       className="relative flex h-20 w-full items-center gap-3 rounded-2xl border border-black/10 p-2 shadow-sm transition-shadow duration-300 hover:shadow-lg sm:p-3 md:h-24"
     >
       {highlight && (
-        <span className="absolute -top-3.5 right-4 z-20 whitespace-nowrap rounded-full border border-primary bg-white px-2 py-1 text-xs font-semibold text-primary uppercase">
+        <span className="absolute -top-3.5 right-4 z-20 whitespace-nowrap rounded-full border border-primary bg-white px-2 py-1 text-xs font-semibold uppercase text-primary">
           {highlight}
         </span>
       )}

--- a/src/contexts/scrollstate-provider.tsx
+++ b/src/contexts/scrollstate-provider.tsx
@@ -12,7 +12,7 @@ const ScrollStateContext = createContext<ScrollStateContextData | undefined>(
 );
 
 export function ScrollStateProvider({
-  children
+  children,
 }: {
   children: React.ReactNode;
 }) {
@@ -43,9 +43,7 @@ export function ScrollStateProvider({
   }, []); // Empty dependency array ensures this runs only once on mount
 
   return (
-    <ScrollStateContext.Provider
-      value={{ isScrolledTop, isScrolledBottom }}
-    >
+    <ScrollStateContext.Provider value={{ isScrolledTop, isScrolledBottom }}>
       {children}
     </ScrollStateContext.Provider>
   );

--- a/src/internationalization/dictionaries/en.json
+++ b/src/internationalization/dictionaries/en.json
@@ -374,7 +374,7 @@
         "color": "#eecc67",
         "perks": [
           {
-            "description": "**Desconto de 10%** em compras superiores a 7€, exceto quartas e domingos.",
+            "description": "**10% discount** on purchases over 7€, except on Wednesdays and Sundays.",
             "icon": "Percent"
           }
         ]
@@ -386,7 +386,7 @@
         "color": "#925b2a",
         "perks": [
           {
-            "description": "Desconto de **10%**.",
+            "description": "**10%** Discount.",
             "icon": "Percent"
           }
         ]
@@ -398,7 +398,7 @@
         "color": "#9a301f",
         "perks": [
           {
-            "description": "**Desconto de 0.50€** em todos os menus confecionados.",
+            "description": "**0.50€ discount** on all prepared menus.",
             "icon": "Euro"
           }
         ]
@@ -410,7 +410,7 @@
         "color": "#843dc2",
         "perks": [
           {
-            "description": "**Oferta de bebida** nos menus Hambúrguer Especial, Tosta Americana, Tosta de Salmão e Cachorro Especial.\n\n**Fanta, Nestea, Água, Sprite, Ginger ale**",
+            "description": "**Free drink** with Special Hamburger, American Toast, Salmon Toast, and Special Hot Dog menus.\n\n**Fanta, Nestea, Water, Sprite, Ginger ale**",
             "icon": "Water_Full"
           }
         ]
@@ -422,7 +422,7 @@
         "color": "#134046",
         "perks": [
           {
-            "description": "**10% de desconto** na compra de jogos de tabuleiro e isenção de consumo mínimo.",
+            "description": "**10% discount** on board games and no minimum consumption.",
             "icon": "Percent"
           }
         ]
@@ -434,7 +434,7 @@
         "color": "#BBB24A",
         "perks": [
           {
-            "description": "**Desconto de 40€** na carta de condução da Categoria B.",
+            "description": "**40€ discount** on Category B driving license.",
             "icon": "Euro"
           }
         ]
@@ -446,15 +446,15 @@
         "color": "#d1a75b",
         "perks": [
           {
-            "description": "Na compra de 8 pins, é **oferecido o pin** de menor valor.",
+            "description": "When purchasing 8 pins, the **pin with the lowest value** is free.",
             "icon": "Sell"
           },
           {
-            "description": "**Desconto de 20%** nos pins de curso.",
+            "description": "**20% discount** on course pins.",
             "icon": "Percent"
           },
           {
-            "description": "**Portes de envio gratuitos** em compras superiores a 12.50€.",
+            "description": "**Free shipping** on purchases over 12.50€.",
             "icon": "Euro"
           }
         ]
@@ -466,7 +466,7 @@
         "color": "#e56b7f",
         "perks": [
           {
-            "description": "**Desconto de 5€** em todas as atividades (música, dança, artes marciais, teatro, etc).",
+            "description": "**5€ discount** on all activities (music, dance, martial arts, theater, etc).",
             "icon": "Euro"
           }
         ]
@@ -478,19 +478,19 @@
         "color": "#7DA279",
         "perks": [
           {
-            "description": "Na compra do traje, **oferta de mais 3 emblemas** (para além dos 4 habituais).",
+            "description": "When purchasing the academic attire, **get 3 additional badges** (in addition to the usual 4).",
             "icon": "License"
           },
           {
-            "description": "Na compra de 4 emblemas, **oferta de 1**.",
+            "description": "When purchasing 4 badges, **get 1 free**.",
             "icon": "License"
           },
           {
-            "description": "Preço de meias para homem: **2.75€**.",
+            "description": "Price of men's socks: **2.75€**.",
             "icon": "Euro"
           },
           {
-            "description": "Preço de meias para mulher: **1.50€**.",
+            "description": "Price of women's socks: **1.50€**.",
             "icon": "Euro"
           }
         ]
@@ -502,15 +502,15 @@
         "color": "#598EBA",
         "perks": [
           {
-            "description": "Refeição e chá por **4.50€**.",
+            "description": "Meal and tea for **4.50€**.",
             "icon": "Sell"
           },
           {
-            "description": "Sobremesa a **1.40€**.",
+            "description": "Dessert for **1.40€**.",
             "icon": "Sell"
           },
           {
-            "description": "Café a **0.60€**.",
+            "description": "Coffee for **0.60€**.",
             "icon": "Sell"
           }
         ]
@@ -522,7 +522,7 @@
         "color": "#89573E",
         "perks": [
           {
-            "description": "**Desconto de 0.40€** no menu estudante e nas pizzas.",
+            "description": "**0.40€ discount** on the student menu and pizzas.",
             "icon": "Euro"
           }
         ]
@@ -534,7 +534,7 @@
         "color": "#68b54a",
         "perks": [
           {
-            "description": "**Oferta de café** na compra de um menu.",
+            "description": "**Free coffee** with the purchase of a menu.",
             "icon": "Coffee"
           }
         ]

--- a/src/internationalization/dictionaries/pt.json
+++ b/src/internationalization/dictionaries/pt.json
@@ -343,47 +343,22 @@
   "sections": [
     {
       "title": "CeSIUM",
-      "items": [
-        "Sobre nós",
-        "Equipa",
-        "Departmentos"
-      ],
-      "links": [
-        "/about",
-        "/team",
-        "/departments"
-      ]
+      "items": ["Sobre nós", "Equipa", "Departmentos"],
+      "links": ["/about", "/team", "/departments"]
     },
     {
       "title": "Atividades",
-      "items": [
-        "Eventos",
-        "Parcerias"
-      ],
-      "links": [
-        "/events",
-        "/partners"
-      ]
+      "items": ["Eventos", "Parcerias"],
+      "links": ["/events", "/partners"]
     },
     {
       "title": "Estudantes",
-      "items": [
-        "Torna-te sócio",
-        "Torna-te colaborador"
-      ],
-      "links": [
-        "/about/become-a-member",
-        "/about/become-a-collaborator"
-      ]
+      "items": ["Torna-te sócio", "Torna-te colaborador"],
+      "links": ["/about/become-a-member", "/about/become-a-collaborator"]
     },
     {
       "title": "Links Úteis",
-      "items": [
-        "CeSIUM Link",
-        "Calendarium",
-        "Blackboard",
-        "Portal do Aluno"
-      ],
+      "items": ["CeSIUM Link", "Calendarium", "Blackboard", "Portal do Aluno"],
       "links": [
         "https://cesium.link",
         "https://calendario.cesium.pt",

--- a/src/internationalization/dictionaries/pt.json
+++ b/src/internationalization/dictionaries/pt.json
@@ -343,22 +343,47 @@
   "sections": [
     {
       "title": "CeSIUM",
-      "items": ["Sobre nós", "Equipa", "Departmentos"],
-      "links": ["/about", "/team", "/departments"]
+      "items": [
+        "Sobre nós",
+        "Equipa",
+        "Departmentos"
+      ],
+      "links": [
+        "/about",
+        "/team",
+        "/departments"
+      ]
     },
     {
       "title": "Atividades",
-      "items": ["Eventos", "Parcerias"],
-      "links": ["/events", "/partners"]
+      "items": [
+        "Eventos",
+        "Parcerias"
+      ],
+      "links": [
+        "/events",
+        "/partners"
+      ]
     },
     {
       "title": "Estudantes",
-      "items": ["Torna-te sócio", "Torna-te colaborador"],
-      "links": ["/about/become-a-member", "/about/become-a-collaborator"]
+      "items": [
+        "Torna-te sócio",
+        "Torna-te colaborador"
+      ],
+      "links": [
+        "/about/become-a-member",
+        "/about/become-a-collaborator"
+      ]
     },
     {
       "title": "Links Úteis",
-      "items": ["CeSIUM Link", "Calendarium", "Blackboard", "Portal do Aluno"],
+      "items": [
+        "CeSIUM Link",
+        "Calendarium",
+        "Blackboard",
+        "Portal do Aluno"
+      ],
       "links": [
         "https://cesium.link",
         "https://calendario.cesium.pt",
@@ -368,8 +393,8 @@
     }
   ],
   "partners": {
-    "title": "Partners",
-    "description": "One of the advantages of being a member of CeSIUM is our incredible partnerships. Discover all the oportunities our partners have for you.",
+    "title": "Parcerias",
+    "description": "Uma das vantagens de ser sócio do CeSIUM são as nossas parcerias incríveis. Descobre todas as ofertas que os nossos parceiros têm para ti.",
     "list": [
       {
         "title": "100 Montaditos",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/43b8c679-720d-449a-a327-7866c625d977)

While navigating through the website, I noticed that the internationalization of this specific page was all wrong, both in English and Portuguese. In Portuguese, the title always appeared in English, and in English, there was no English text version for the benefits of each partner on the partner card. I simply fixed those problems. Please check the translations to see if they match what was expected. The translated sentences were simple enough, but I might have missed something.